### PR TITLE
First part of nginx changes for AWS load balancing

### DIFF
--- a/conf/salt/project/web/balancer.sls
+++ b/conf/salt/project/web/balancer.sls
@@ -12,6 +12,7 @@ http_firewall:
     - names:
       - '80'
       - '443'
+      - '8088'
     - enabled: true
 
 public_dir:

--- a/conf/salt/project/web/site.conf
+++ b/conf/salt/project/web/site.conf
@@ -94,3 +94,93 @@ server {
     server_name _;
     return 301 https://{{ pillar['domain'] }}$request_uri;
 }
+
+server {
+    {# requests proxied through AWS ELB #}
+    listen 8088;
+    # http://serverfault.com/questions/331531/nginx-set-real-ip-from-aws-elb-load-balancer-address
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header X-Forwarded-For;
+
+    {# ALL THIS COPIED FROM ABOVE - JUST TEMPORARILY DUPLICATED BECAUSE EVERYTHING #}
+    {# ABOVE IS GOING AWAY. #}
+    server_name {{ pillar['domain'] }};
+    root {{ public_root }};
+
+    keepalive_timeout 5;
+    proxy_read_timeout 180s;
+
+    access_log {{ log_dir }}/nginx.access.log;
+    error_log {{ log_dir }}/nginx.error.log;
+
+    add_header Strict-Transport-Security max-age=31536000;
+
+    if ($host !~* ^({{ pillar['domain'] }}|www.{{ pillar['domain'] }})$) {
+        # Deny non-matching Host headers
+        return 444;
+    }
+
+    location /robots.txt {
+        alias {{ public_root }}/static/robots.txt;
+    }
+
+    location /media {
+        alias {{ public_root }}/media;
+    }
+
+    location /static {
+        gzip on;
+        alias {{ public_root }}/static;
+        expires max;
+        add_header Cache-Control public;
+
+        location /static/protected {
+            return 401;
+        }
+    }
+
+    # See https://github.com/johnsensible/django-sendfile and http://wiki.nginx.org/XSendfile
+    location /protected/ {
+        internal;
+        # Note: the location path ("/protected/") is concatenated onto the root, so don't repeat it:
+        root {{ public_root }}/static/;
+    }
+
+    error_page 502 503 504 /502.html;
+
+    location /502.html {
+        alias {{ public_root }}/static/502.html;
+    }
+
+  {% for instance in salt['pillar.get']('instances') %}
+    {% set port = salt['pillar.get']('instances:' + instance + ':port') %}
+    {% set prefix = salt['pillar.get']('instances:' + instance + ':prefix') %}
+    # The value of 'prefix' includes a leading /
+    location {{ prefix }}/ {
+        gzip off;
+        access_log {{ log_dir }}/{{ instance }}/nginx.access.log;
+        error_log {{ log_dir }}/{{ instance }}/nginx.error.log;
+        {% if 'http_auth' in pillar %}
+        auth_basic "Restricted";
+        auth_basic_user_file {{ auth_file }};
+        {% endif %}
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Protocol ssl;
+        proxy_set_header Host {{ pillar['domain'] }};
+        proxy_redirect off;
+        proxy_buffering on;
+        proxy_intercept_errors on;
+
+        # http://nginx.com/resources/admin-guide/reverse-proxy/
+        proxy_pass http://127.0.0.1:{{ port }};
+    }
+  {% endfor %}
+
+    location = / {
+      # Show the instance list, on any instance - just use the first in the list
+      {% set instance = salt['pillar.get']('instances').keys()[0] %}
+      {% set prefix = salt['pillar.get']('instances:' + instance + ':prefix') %}
+      return 301 "{{ prefix }}/instances/";
+    }
+}

--- a/conf/salt/project/web/site.conf
+++ b/conf/salt/project/web/site.conf
@@ -1,3 +1,31 @@
+{% set first_instance = salt['pillar.get']('instances').keys()[0] %}
+{% macro get_port(instance) %}{{ salt['pillar.get']('instances:' + instance + ':port') }}{% endmacro %}
+{% macro get_prefix(instance) %}{{ salt['pillar.get']('instances:' + instance + ':prefix') }}{% endmacro %}
+
+{% macro proxy_to(instance, auth=True, proxy_pass=None) %}
+    gzip off;
+    access_log {{ log_dir }}/{{ instance }}/nginx.access.log;
+    error_log {{ log_dir }}/{{ instance }}/nginx.error.log;
+    {% if auth and 'http_auth' in pillar %}
+    auth_basic "Restricted";
+    auth_basic_user_file {{ auth_file }};
+    {% endif %}
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Protocol ssl;
+    proxy_set_header Host {{ pillar['domain'] }};
+    proxy_redirect off;
+    proxy_buffering on;
+    proxy_intercept_errors on;
+
+    # http://nginx.com/resources/admin-guide/reverse-proxy/
+    {% if proxy_pass %}
+      proxy_pass {{ proxy_pass }};
+    {% else %}
+      proxy_pass http://127.0.0.1:{{ get_port(instance) }};
+    {% endif %}
+{% endmacro %}
+
 server {
     listen 443;
     server_name {{ pillar['domain'] }};
@@ -56,39 +84,20 @@ server {
     }
 
   {% for instance in salt['pillar.get']('instances') %}
-    {% set port = salt['pillar.get']('instances:' + instance + ':port') %}
-    {% set prefix = salt['pillar.get']('instances:' + instance + ':prefix') %}
     # The value of 'prefix' includes a leading /
-    location {{ prefix }}/ {
-        gzip off;
-        access_log {{ log_dir }}/{{ instance }}/nginx.access.log;
-        error_log {{ log_dir }}/{{ instance }}/nginx.error.log;
-        {% if 'http_auth' in pillar %}
-        auth_basic "Restricted";
-        auth_basic_user_file {{ auth_file }};
-        {% endif %}
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Protocol ssl;
-        proxy_set_header Host {{ pillar['domain'] }};
-        proxy_redirect off;
-        proxy_buffering on;
-        proxy_intercept_errors on;
-
-        # http://nginx.com/resources/admin-guide/reverse-proxy/
-        proxy_pass http://127.0.0.1:{{ port }};
+    location {{ get_prefix(instance) }}/ {
+      {{ proxy_to(instance) }}
     }
   {% endfor %}
 
     location = / {
       # Show the instance list, on any instance - just use the first in the list
-      {% set instance = salt['pillar.get']('instances').keys()[0] %}
-      {% set prefix = salt['pillar.get']('instances:' + instance + ':prefix') %}
-      return 301 "{{ prefix }}/instances/";
+      return 301 "{{ get_prefix(first_instance) }}/instances/";
     }
 }
 
-{# redirect other server names to the real one (http://nginx.org/en/docs/http/converting_rewrite_rules.html under "A redirect to a main site") #}
+# redirect other server names to the real one
+# (http://nginx.org/en/docs/http/converting_rewrite_rules.html under "A redirect to a main site")
 server {
     listen 80 default_server;
     server_name _;
@@ -96,7 +105,7 @@ server {
 }
 
 server {
-    {# requests proxied through AWS ELB #}
+    # requests proxied through AWS ELB
     listen 8088;
     # http://serverfault.com/questions/331531/nginx-set-real-ip-from-aws-elb-load-balancer-address
     set_real_ip_from 0.0.0.0/0;
@@ -104,7 +113,8 @@ server {
 
     {# ALL THIS COPIED FROM ABOVE - JUST TEMPORARILY DUPLICATED BECAUSE EVERYTHING #}
     {# ABOVE IS GOING AWAY. #}
-    server_name {{ pillar['domain'] }};
+    # Allow empty Host because ELB health checker doesn't send Host header.
+    server_name {{ pillar['domain'] }} "";
     root {{ public_root }};
 
     keepalive_timeout 5;
@@ -114,11 +124,6 @@ server {
     error_log {{ log_dir }}/nginx.error.log;
 
     add_header Strict-Transport-Security max-age=31536000;
-
-    if ($host !~* ^({{ pillar['domain'] }}|www.{{ pillar['domain'] }})$) {
-        # Deny non-matching Host headers
-        return 444;
-    }
 
     location /robots.txt {
         alias {{ public_root }}/static/robots.txt;
@@ -152,35 +157,23 @@ server {
         alias {{ public_root }}/static/502.html;
     }
 
-  {% for instance in salt['pillar.get']('instances') %}
-    {% set port = salt['pillar.get']('instances:' + instance + ':port') %}
-    {% set prefix = salt['pillar.get']('instances:' + instance + ':prefix') %}
-    # The value of 'prefix' includes a leading /
-    location {{ prefix }}/ {
-        gzip off;
-        access_log {{ log_dir }}/{{ instance }}/nginx.access.log;
-        error_log {{ log_dir }}/{{ instance }}/nginx.error.log;
-        {% if 'http_auth' in pillar %}
-        auth_basic "Restricted";
-        auth_basic_user_file {{ auth_file }};
-        {% endif %}
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Protocol ssl;
-        proxy_set_header Host {{ pillar['domain'] }};
-        proxy_redirect off;
-        proxy_buffering on;
-        proxy_intercept_errors on;
+    {% for instance in salt['pillar.get']('instances') %}
+        # The value of 'prefix' includes a leading /
+        location {{ get_prefix(instance) }}/ {
+            {{ proxy_to(instance) }}
+        }
+    {% endfor %}
 
-        # http://nginx.com/resources/admin-guide/reverse-proxy/
-        proxy_pass http://127.0.0.1:{{ port }};
+    # /health/ is a health check from ELB. Proxy it to the first instance, inserting
+    # the prefix into the URL.
+    location = /health/ {
+        {{ proxy_to(first_instance, auth=False, proxy_pass="http://127.0.0.1:" +  get_port(first_instance) + get_prefix(first_instance) + "/health/") }}
     }
-  {% endfor %}
 
     location = / {
       # Show the instance list, on any instance - just use the first in the list
-      {% set instance = salt['pillar.get']('instances').keys()[0] %}
-      {% set prefix = salt['pillar.get']('instances:' + instance + ':prefix') %}
-      return 301 "{{ prefix }}/instances/";
+      # Need to include the full domain, otherwise the client gets exposed to
+      # the backend's internal port number for some reason.
+      return 301 "https://{{ pillar['domain'] }}{{ get_prefix(first_instance) }}/instances/";
     }
 }

--- a/fabfile.py
+++ b/fabfile.py
@@ -27,23 +27,17 @@ INSTANCES = projects['instances'].keys()  # e.g. 'iraq', 'turkey'
 
 
 @task
-def testing():
-    env.environment = 'testing'
-    env.hosts = ['ec2-54-146-90-35.compute-1.amazonaws.com']
-
-
-@task
 def staging():
     env.environment = 'staging'
-    env.hosts = ['cts-staging.rescue.org']
+    # This hostname for our own use to connect to the server to manage it.
+    env.hosts = ['ec2-54-86-123-211.compute-1.amazonaws.com']
 
 
 @task
 def production():
     env.environment = 'production'
     # This hostname for our own use to connect to the server to manage it.
-    # IRC might choose to use whatever domain they want for the web site.
-    env.hosts = ['cts.rescue.org']
+    env.hosts = ['ec2-54-77-174-184.eu-west-1.compute.amazonaws.com']
 
 
 @task

--- a/fabfile.py
+++ b/fabfile.py
@@ -30,6 +30,7 @@ INSTANCES = projects['instances'].keys()  # e.g. 'iraq', 'turkey'
 def staging():
     env.environment = 'staging'
     # This hostname for our own use to connect to the server to manage it.
+    # To change the public domain, see conf/pillar/<envname>/env.sls
     env.hosts = ['ec2-54-86-123-211.compute-1.amazonaws.com']
 
 
@@ -37,6 +38,7 @@ def staging():
 def production():
     env.environment = 'production'
     # This hostname for our own use to connect to the server to manage it.
+    # To change the public domain, see conf/pillar/<envname>/env.sls
     env.hosts = ['ec2-54-77-174-184.eu-west-1.compute.amazonaws.com']
 
 


### PR DESCRIPTION
* Add a server listening on 8088 that gets the client IP address
  from the X-Forwarded-for header and otherwise works the same as
  our port 443 server, except for not using SSL.

* Later on we can remove our port 80 & 443 servers and just have
  this 8088 one.