### PR TITLE
Restart celery workers nightly

### DIFF
--- a/conf/salt/project/worker/default.sls
+++ b/conf/salt/project/worker/default.sls
@@ -38,4 +38,12 @@ include:
     - require:
       - file: {{ instance }}_conf
 
+nightly-restart-{{ instance }}-celery:
+  cron.present:
+    - identifier: nightly-restart-{{ instance }}-celery
+    - user: root
+    - name: /usr/local/bin/supervisorctl restart {{ pillar['project_name'] }}-celery-{{ instance }}
+    - hour: 23
+    - minute: 30
+
 {% endfor %}


### PR DESCRIPTION
The celery worker processes seem to be getting hung once a week or more,
and stop processing new package scans. Restarting them seems to get
them going again. Unfortunately we don't have a good way to monitor
them for being "hung" but this should work around it for now.